### PR TITLE
Removing overloaded  method in the  class, since it adds just the direct...

### DIFF
--- a/_plugins/alias_generator.rb
+++ b/_plugins/alias_generator.rb
@@ -93,10 +93,6 @@ module Jekyll
   class AliasFile < StaticFile
     require 'set'
 
-    def destination(dest)
-      File.join(dest, @dir)
-    end
-
     def modified?
       return false
     end


### PR DESCRIPTION
...ory path to the alias file to the list of site static files, not the actual filename. The incorrect destination causes the Jekyll cleaner to remove it shortly after the plugin generates it.
